### PR TITLE
Add a gitlab library

### DIFF
--- a/test/groovy/GitTest.groovy
+++ b/test/groovy/GitTest.groovy
@@ -19,7 +19,7 @@ class GitTest extends BasePipelineTest {
         def script = loadScript('vars/git.groovy')
         try {
             script.diffFiles()
-            assert false : 'diffFiles should have failed'
+            throw new RuntimeException('should not have reached here')
         } catch (AssertionError err) {
             println("[INFO] Caught expected AssertionError: ${err}")
         }
@@ -86,7 +86,7 @@ class GitTest extends BasePipelineTest {
         def script = loadScript('vars/git.groovy')
         try {
             script.merge(targetBranch: 'target', gitCredentialsId: 'some-creds')
-            assert false : 'Should have failed'
+            throw new RuntimeException('should not have reached here')
         } catch(AssertionError err) {
             println('[INFO] Caught expected AssertionError')
         }
@@ -97,7 +97,7 @@ class GitTest extends BasePipelineTest {
         def script = loadScript('vars/git.groovy')
         try {
             script.merge(sourceBranch: 'source', gitCredentialsId: 'some-creds')
-            assert false : 'Should have failed'
+            throw new RuntimeException('should not have reached here')
         } catch(AssertionError err) {
             println('[INFO] Caught expected AssertionError')
         }
@@ -108,7 +108,7 @@ class GitTest extends BasePipelineTest {
         def script = loadScript('vars/git.groovy')
         try {
             script.merge(currentBranch: 'source', targetBranch: 'target')
-            assert false : 'Should have failed'
+            throw new RuntimeException('should not have reached here')
         } catch(AssertionError err) {
             println('[INFO] Caught expected AssertionError')
         }

--- a/test/groovy/GitlabTest.groovy
+++ b/test/groovy/GitlabTest.groovy
@@ -24,7 +24,7 @@ class GitlabTest extends BasePipelineTest {
         def script = loadScript('vars/gitlab.groovy')
         try {
             script.internal_gitlabRequest()
-            assert false : 'internal_gitlabRequest should have failed'
+            throw new RuntimeException('should not have reached here')
         } catch (AssertionError err) {
             println("[INFO] Caught expected AssertionError: ${err}")
         }
@@ -82,7 +82,7 @@ class GitlabTest extends BasePipelineTest {
         def script = loadScript('vars/gitlab.groovy')
         try {
             script.internal_getMergeRequest(mergeRequestId: '5')
-            assert false : 'internal_gitlabRequest should have failed'
+            throw new RuntimeException('should not have reached here')
         } catch (AssertionError err) {
             println("[INFO] Caught expected AssertionError: ${err}")
         }
@@ -93,7 +93,7 @@ class GitlabTest extends BasePipelineTest {
         def script = loadScript('vars/gitlab.groovy')
         try {
             script.internal_getMergeRequest(projectId: '5')
-            assert false : 'internal_getMergeRequest should have failed'
+            throw new RuntimeException('should not have reached here')
         } catch (AssertionError err) {
             println("[INFO] Caught expected AssertionError: ${err}")
         }
@@ -127,7 +127,7 @@ class GitlabTest extends BasePipelineTest {
         def script = loadScript('vars/gitlab.groovy')
         try {
             script.mergeRequestComment(projectId: '5', mergeRequestId: '10')
-            assert false : 'internal_getMergeRequest should have failed'
+            throw new RuntimeException('should not have reached here')
         } catch (AssertionError err) {
             println("[INFO] Caught expected AssertionError: ${err}")
         }
@@ -138,7 +138,7 @@ class GitlabTest extends BasePipelineTest {
         def script = loadScript('vars/gitlab.groovy')
         try {
             script.mergeRequestComment(message: 'some message', mergeRequestId: '10')
-            assert false : 'internal_getMergeRequest should have failed'
+            throw new RuntimeException('should not have reached here')
         } catch (AssertionError err) {
             println("[INFO] Caught expected AssertionError: ${err}")
         }
@@ -149,7 +149,7 @@ class GitlabTest extends BasePipelineTest {
         def script = loadScript('vars/gitlab.groovy')
         try {
             script.mergeRequestComment(message: 'some message', projectId: '5')
-            assert false : 'internal_getMergeRequest should have failed'
+            throw new RuntimeException('should not have reached here')
         } catch (AssertionError err) {
             println("[INFO] Caught expected AssertionError: ${err}")
         }
@@ -166,5 +166,66 @@ class GitlabTest extends BasePipelineTest {
                                               mergeRequestId: '10')
         assert resp == ['body': '{"body":"some message"}', 'uri': 'api/v4/projects/5/merge_requests/10/discussions',
                         'mode': 'POST', 'credentials': 'amber-gitlab-automaton-token']
+    }
+
+    @Test
+    void 'internal_gitlabUploadAttachment requires a fileName'() {
+        helper.registerAllowedMethod('fileExists', [String.class], {fileName -> true})
+        def script = loadScript('vars/gitlab.groovy')
+        try {
+            script.internal_gitlabUploadAttachment(projectId: '5')
+            throw new RuntimeException('should not have reached here')
+        } catch (AssertionError err) {
+            println("[INFO] Caught expected AssertionError: ${err}")
+        }
+    }
+
+    @Test
+    void 'internal_gitlabUploadAttachment requires a projectId'() {
+        helper.registerAllowedMethod('fileExists', [String.class], {fileName -> true})
+        def script = loadScript('vars/gitlab.groovy')
+        try {
+            script.internal_gitlabUploadAttachment(fileName: 'some-file.png')
+            throw new RuntimeException('should not have reached here')
+        } catch (AssertionError err) {
+            println("[INFO] Caught expected AssertionError: ${err}")
+        }
+    }
+
+    @Test
+    void 'internal_gitlabUploadAttachment requires a file that exists'() {
+        helper.registerAllowedMethod('fileExists', [String.class], {fileName -> false})
+        def script = loadScript('vars/gitlab.groovy')
+        try {
+            script.internal_gitlabUploadAttachment(fileName: 'some-file.png', projectId: '5')
+            throw new RuntimeException('should not have reached here')
+        } catch (AssertionError err) {
+            println("[INFO] Caught expected AssertionError: ${err}")
+        }
+    }
+
+    @Test
+    void 'verify internal_gitlabUploadAttachment defaults'() {
+        helper.registerAllowedMethod('fileExists', [String.class], {fileName ->
+            return fileName == 'some-file.png'
+        })
+        helper.registerAllowedMethod('httpRequest', [Map.class], {params ->
+            assert params.wrapAsMultipart
+            assert params.multipartName == 'file'
+            assert params.httpMode == 'POST'
+            assert params.uploadFile == 'some-file.png'
+            assert params.url == 'https://gitlab.ambermd.org/api/v4/projects/5/uploads'
+            return new HttpResponse('{"some": "json"}', 201)
+        })
+        binding.setVariable('GITLAB_TOKEN', 'gitlab-api-token')
+        def script = loadScript('vars/gitlab.groovy')
+        Map resp = script.internal_gitlabUploadAttachment(projectId: '5', fileName: 'some-file.png')
+        assert resp.some == 'json' : 'Did not properly deserialize expected response'
+
+        List requestCalls = helper.callStack.findAll {call -> call.methodName == 'httpRequest'}
+        assert requestCalls.size() == 1 : 'Should have made 1 httpRequest call'
+
+        List credCalls = helper.callStack.findAll {call -> call.methodName == 'withCredentials'}
+        assert credCalls.size() == 1 : 'Should have executed one withCredentials call'
     }
 }

--- a/test/groovy/GitlabTest.groovy
+++ b/test/groovy/GitlabTest.groovy
@@ -164,7 +164,7 @@ class GitlabTest extends BasePipelineTest {
         }
         Map resp = script.mergeRequestComment(message: 'some message', projectId: '5',
                                               mergeRequestId: '10')
-        assert resp == ['body': '{"body":"some message"}', 'uri': 'api/v4/projects/5/merge_requests/10/discussion',
+        assert resp == ['body': '{"body":"some message"}', 'uri': 'api/v4/projects/5/merge_requests/10/discussions',
                         'mode': 'POST', 'credentials': 'amber-gitlab-automaton-token']
     }
 }

--- a/test/groovy/GitlabTest.groovy
+++ b/test/groovy/GitlabTest.groovy
@@ -1,0 +1,124 @@
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import org.junit.Before
+import org.junit.Test
+import mock.HttpResponse
+import groovy.json.JsonSlurper
+
+class GitlabTest extends BasePipelineTest {
+
+    @Override
+    @Before
+    void setUp() {
+        super.setUp()
+        helper.registerAllowedMethod('echo', [String.class], {label -> println(label)})
+        helper.registerAllowedMethod('withCredentials', [List.class, Closure.class], {creds, closure ->
+            closure.call()
+        })
+        helper.registerAllowedMethod('readJSON', [Map.class], {content ->
+            return (new JsonSlurper()).parseText(content.text)
+        })
+    }
+
+    @Test
+    void 'internal_gitlabRequest requires a uri'() {
+        def script = loadScript('vars/gitlab.groovy')
+        try {
+            script.internal_gitlabRequest()
+            assert false : 'internal_gitlabRequest should have failed'
+        } catch (AssertionError err) {
+            println("[INFO] Caught expected AssertionError: ${err}")
+        }
+    }
+
+    @Test
+    void 'verify internal_gitlabRequest defaults'() {
+        helper.registerAllowedMethod('httpRequest', [Map.class], {params ->
+            return new HttpResponse('{"some": "json"}', 200)
+        })
+        binding.setVariable('GITLAB_TOKEN', 'gitlab-api-token')
+        def script = loadScript('vars/gitlab.groovy')
+        Map resp = script.internal_gitlabRequest(uri: 'api/v4/projects')
+        assert resp.some == 'json' : 'Did not properly deserialize expected response'
+
+        List requestCalls = helper.callStack.findAll {call -> call.methodName == 'httpRequest'}
+        assert requestCalls.size() == 1 : 'Should have made 1 httpRequest call'
+        assert requestCalls[0].args[0].customHeaders.size() == 1 : 'Expected auth header'
+        assert requestCalls[0].args[0].customHeaders[0].name == 'Authorization' : 'expected auth header'
+        assert requestCalls[0].args[0].customHeaders[0].value == 'Bearer gitlab-api-token' : 'expected default token auth'
+        assert requestCalls[0].args[0].httpMode == 'GET' : 'GET should be default method'
+        assert requestCalls[0].args[0].validResponseCodes == '100:399' : 'Default valid codes should all be <400'
+
+        List credCalls = helper.callStack.findAll {call -> call.methodName == 'withCredentials'}
+        assert credCalls.size() == 1 : 'Should have executed one withCredentials call'
+        assert credCalls[0].args[0].size() == 1 : 'Should have only used 1 set of creds'
+    }
+
+    @Test
+    void 'verify overridden internal_gitlabRequest parameters'() {
+        helper.registerAllowedMethod('httpRequest', [Map.class], {params ->
+            return new HttpResponse('{"some": "json"}', 200)
+        })
+        binding.setVariable('GITLAB_TOKEN', 'gitlab-api-token')
+        def script = loadScript('vars/gitlab.groovy')
+        Map resp = script.internal_gitlabRequest(uri: 'api/v4/projects', httpMode: 'POST',
+                                                 validResponseCodes: '100:599')
+        assert resp.some == 'json' : 'Did not properly deserialize expected response'
+
+        List requestCalls = helper.callStack.findAll {call -> call.methodName == 'httpRequest'}
+        assert requestCalls.size() == 1 : 'Should have made 1 httpRequest call'
+        assert requestCalls[0].args[0].customHeaders.size() == 1 : 'Expected auth header'
+        assert requestCalls[0].args[0].customHeaders[0].name == 'Authorization' : 'expected auth header'
+        assert requestCalls[0].args[0].customHeaders[0].value == 'Bearer gitlab-api-token' : 'expected default token auth'
+        assert requestCalls[0].args[0].httpMode == 'POST' : 'POST was specified'
+        assert requestCalls[0].args[0].validResponseCodes == '100:599' : 'Should take custom valid codes'
+
+        List credCalls = helper.callStack.findAll {call -> call.methodName == 'withCredentials'}
+        assert credCalls.size() == 1 : 'Should have executed one withCredentials call'
+        assert credCalls[0].args[0].size() == 1 : 'Should have only used 1 set of creds'
+    }
+
+    @Test
+    void 'internal_getMergeRequest requires a project ID'() {
+        def script = loadScript('vars/gitlab.groovy')
+        try {
+            script.internal_getMergeRequest(mergeRequestId: '5')
+            assert false : 'internal_gitlabRequest should have failed'
+        } catch (AssertionError err) {
+            println("[INFO] Caught expected AssertionError: ${err}")
+        }
+    }
+
+    @Test
+    void 'internal_getMergeRequest requires a merge request ID'() {
+        def script = loadScript('vars/gitlab.groovy')
+        try {
+            script.internal_getMergeRequest(projectId: '5')
+            assert false : 'internal_getMergeRequest should have failed'
+        } catch (AssertionError err) {
+            println("[INFO] Caught expected AssertionError: ${err}")
+        }
+    }
+
+    @Test
+    void 'internal_getMergeRequest correctly processes response'() {
+        def script = loadScript('vars/gitlab.groovy')
+        script.metaClass.internal_gitlabRequest = {Map params = [:] ->
+            assert params.uri == 'api/v4/projects/5/merge_requests/10'
+            return ['foo': 'bar']
+        }
+        Map resp = script.internal_getMergeRequest(projectId: '5', mergeRequestId: '10')
+        assert resp.foo == 'bar' : 'Unexpected response from internal_getMergeRequest'
+    }
+
+    @Test
+    void 'mergeRequestAuthor correctly returns just the author'() {
+        def script = loadScript('vars/gitlab.groovy')
+        script.metaClass.internal_getMergeRequest = {Map params ->
+            assert params.projectId == '5'
+            assert params.mergeRequestId == '10'
+            return ['extra': 'parameter', 'author' : ['username': 'foo', 'email': 'bar@email.com']]
+        }
+        Map resp = script.mergeRequestAuthor(projectId: '5', mergeRequestId: '10')
+        assert resp == ['username': 'foo', 'email': 'bar@email.com'] : 'Unexpected response'
+    }
+}

--- a/test/groovy/GitlabTest.groovy
+++ b/test/groovy/GitlabTest.groovy
@@ -156,6 +156,45 @@ class GitlabTest extends BasePipelineTest {
     }
 
     @Test
+    void 'mergeRequestComment with files requires tokens to exist'() {
+        def script = loadScript('vars/gitlab.groovy')
+        helper.registerAllowedMethod('fileExists', [String.class], {name -> true})
+        try {
+            script.mergeRequestComment(message: 'some-message', projectId: '5', mergeRequestId: '10',
+                                       files: ['file1.png', 'file2.jpg', 'file3.tgz'])
+            throw new RuntimeException('should not have reached here')
+        } catch (AssertionError err) {
+            println("[INFO] Caught expected AssertionError: ${err}")
+        }
+    }
+
+    @Test
+    void 'mergeRequestComment with files requires all tokens to exist'() {
+        def script = loadScript('vars/gitlab.groovy')
+        helper.registerAllowedMethod('fileExists', [String.class], {name -> true})
+        try {
+            script.mergeRequestComment(message: 'some-message FILE1 FILE2', projectId: '5', mergeRequestId: '10',
+                                       files: ['file1.png', 'file2.jpg', 'file3.tgz'])
+            throw new RuntimeException('should not have reached here')
+        } catch (AssertionError err) {
+            println("[INFO] Caught expected AssertionError: ${err}")
+        }
+    }
+
+    @Test
+    void 'mergeRequestComment with files requires files to exist'() {
+        def script = loadScript('vars/gitlab.groovy')
+        helper.registerAllowedMethod('fileExists', [String.class], {name -> name != 'file3.tgz'})
+        try {
+            script.mergeRequestComment(message: 'FILE1 FILE2 FILE3', projectId: '5', mergeRequestId: '10',
+                                       files: ['file1.png', 'file2.jpg', 'file3.tgz'])
+            throw new RuntimeException('should not have reached here')
+        } catch (AssertionError err) {
+            println("[INFO] Caught expected AssertionError: ${err}")
+        }
+    }
+
+    @Test
     void 'mergeRequestComment sends a request to the GitLab API'() {
         def script = loadScript('vars/gitlab.groovy')
         script.metaClass.internal_gitlabRequest = {Map params ->

--- a/test/groovy/mock/Docker.groovy
+++ b/test/groovy/mock/Docker.groovy
@@ -4,9 +4,9 @@ package mock
  * Mock Docker class from docker-workflow plugin.
  */
 class Docker implements Serializable {
-  public Image image(String id) { new Image(this, id) }
-  public class Image implements Serializable {
-    private Image(Docker docker, String id) {}
-    public <V> V inside(String args = '', Closure<V> body) { body() }
-  }
+    public Image image(String id) { new Image(this, id) }
+    public class Image implements Serializable {
+        private Image(Docker docker, String id) {}
+        public <V> V inside(String args = '', Closure<V> body) { body() }
+    }
 }

--- a/test/groovy/mock/HttpResponse.groovy
+++ b/test/groovy/mock/HttpResponse.groovy
@@ -1,0 +1,23 @@
+package mock
+
+/**
+ * Mock Docker class from docker-workflow plugin.
+ */
+class HttpResponse {
+
+  public String content
+  public int status_code
+
+  HttpResponse(String content, int status_code) {
+    this.content = content
+    this.status_code = status_code
+  }
+
+  String getContent() {
+    return this.content
+  }
+
+  int getStatus() {
+    return this.status_code
+  }
+}

--- a/vars/gitlab.groovy
+++ b/vars/gitlab.groovy
@@ -55,10 +55,6 @@ Map mergeRequestComment(Map params = [:]) {
     String credentialsId = params.gitlabCredentialsId ?: defaultCredentialsId
     String[] files = params.files ?: []
 
-    if (params.individualNote) {
-        body['individual_note'] = true
-    }
-
     if (files.size() > 1) {
         for (int i = 1; i <= files.size(); i++) {
             String token = "FILE${i}"
@@ -79,6 +75,9 @@ Map mergeRequestComment(Map params = [:]) {
     }
 
     Map body = ['body': message]
+    if (params.individualNote) {
+        body['individual_note'] = true
+    }
 
     return internal_gitlabRequest(
         uri: "api/v4/projects/${params.projectId}/merge_requests/${params.mergeRequestId}/discussions",

--- a/vars/gitlab.groovy
+++ b/vars/gitlab.groovy
@@ -48,7 +48,7 @@ Map mergeRequestComment(Map params = [:]) {
     assert params.mergeRequestId : 'mergeRequestId is required'
 
     return internal_gitlabRequest(
-        uri: "api/v4/projects/${params.projectId}/merge_requests/${params.mergeRequestId}/discussion",
+        uri: "api/v4/projects/${params.projectId}/merge_requests/${params.mergeRequestId}/discussions",
         requestBody: JsonOutput.toJson(['body': params.message]),
         credentialsId: params.gitlabCredentialsId ?: defaultCredentialsId,
         httpMode: 'POST',

--- a/vars/gitlab.groovy
+++ b/vars/gitlab.groovy
@@ -1,0 +1,82 @@
+/**
+ * This package contains functionality for interacting with the REST API of
+ * GitLab. This uses the v4 version of the API.
+ *
+ * The authentication mode assumed here uses user tokens. See more at
+ * https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html
+ *
+ * gitlabCredentialsId should always be a "secret text" type of credentials
+ */
+import groovy.transform.Field
+
+// This should be set to the address of the GitLab server you wish to use
+@Field String GITLAB_SERVER = 'https://gitlab.ambermd.org'
+
+// This can be overridden on a per-function basis
+@Field String defaultCredentialsId = 'amber-gitlab-automaton-token'
+
+/**
+ * Gets the full set of details about a given merge request
+ *
+ * :param projectId: The ID of the project. Required
+ * :param mergeRequestId: This is the merge request Iid (not Id), which is the
+ *                        project-specific ID, not the globally-unique ID. Required
+ * :param gitlabCredentialsId: The credentials ID storing the GitLab access token to use.
+ *                             Default is 'amber-gitlab-automaton-token'
+ * :returns: the user information of the person that raised the merge request
+ */
+Map mergeRequestAuthor(Map params = [:]) {
+
+    Map mergeRequest = internal_getMergeRequest(params)
+    return mergeRequest.author
+}
+
+/**
+ * Internal method for getting a merge request from the REST API
+ *
+ * :param projectId: The ID of the project. Required
+ * :param mergeRequestId: This is the merge request Iid (not Id), which is the
+ *                        project-specific ID, not the globally-unique ID. Required
+ * :param gitlabCredentialsId: The credentials ID storing the GitLab access token to use.
+ *                             Default is 'amber-gitlab-automaton-token'
+ * :returns: Map that is the deserialized response from the GitLab API
+ */
+Map internal_getMergeRequest(Map params = [:]) {
+    assert params.projectId : 'projectId is required'
+    assert params.mergeRequestId : 'mergeRequestId is required'
+
+    String projectId = params.projectId
+    String mergeRequestId = params.mergeRequestId
+
+    return internal_gitlabRequest(
+        uri: "api/v4/projects/${projectId}/merge_requests/${mergeRequestId}",
+        credentialsId: params.gitlabCredentialsId ?: defaultCredentialsId,
+    )
+}
+
+/// Utility to send arbitrary gitlab REST requests with auth headers
+Map internal_gitlabRequest(Map params = [:]) {
+    assert params.uri : 'uri is required'
+
+    String uri = params.uri
+    String credentialsId = params.credentialsId ?: defaultCredentialsId
+    String validResponseCodes = params.validResponseCodes ?: '100:399'
+    String httpMode = params.httpMode ?: 'GET'
+
+    Map response
+
+    withCredentials([string(credentialsId: credentialsId, variable: 'GITLAB_TOKEN')]) {
+        def resp = httpRequest(
+            url: "${GITLAB_SERVER}/${uri}"
+            acceptType: 'APPLICATION_JSON',
+            contentType: 'APPLICATION_JSON',
+            httpMode: httpMode,
+            customHeaders: [
+                [name: 'Authorization', value: "Bearer ${GITLAB_TOKEN}", maskValue: true]
+            ],
+            validResponseCodes: validResponseCodes,
+        )
+        response = readJSON(text: resp.getContent())
+    }
+    return response
+}

--- a/vars/gitlab.groovy
+++ b/vars/gitlab.groovy
@@ -8,6 +8,7 @@
  * gitlabCredentialsId should always be a "secret text" type of credentials
  */
 import groovy.transform.Field
+import groovy.json.JsonOutput
 
 // This should be set to the address of the GitLab server you wish to use
 @Field String GITLAB_SERVER = 'https://gitlab.ambermd.org'
@@ -48,7 +49,7 @@ Map mergeRequestComment(Map params = [:]) {
 
     return internal_gitlabRequest(
         uri: "api/v4/projects/${params.projectId}/merge_requests/${params.mergeRequestId}/discussion",
-        requestBody: ['body': params.message],
+        requestBody: JsonOutput.toJson(['body': params.message]),
         credentialsId: params.gitlabCredentialsId ?: defaultCredentialsId,
         httpMode: 'POST',
     )

--- a/vars/gitlab.groovy
+++ b/vars/gitlab.groovy
@@ -67,7 +67,7 @@ Map internal_gitlabRequest(Map params = [:]) {
 
     withCredentials([string(credentialsId: credentialsId, variable: 'GITLAB_TOKEN')]) {
         def resp = httpRequest(
-            url: "${GITLAB_SERVER}/${uri}"
+            url: "${GITLAB_SERVER}/${uri}",
             acceptType: 'APPLICATION_JSON',
             contentType: 'APPLICATION_JSON',
             httpMode: httpMode,

--- a/vars/gitlab.groovy
+++ b/vars/gitlab.groovy
@@ -40,12 +40,18 @@ Map mergeRequestAuthor(Map params = [:]) {
  *                        project-specific ID, not the globally-unique ID. Required
  * :param gitlabCredentialsId: The credentials ID storing the GitLab access token to use.
  *                             Default is 'amber-gitlab-automaton-token'
+ * :param individualNote: if true, make this an individual note instead of a thread
  * :returns: the REST API response
  */
 Map mergeRequestComment(Map params = [:]) {
     assert params.message : 'message is required'
     assert params.projectId : 'projectId is required'
     assert params.mergeRequestId : 'mergeRequestId is required'
+
+    Map body = ['body': params.message]
+    if (params.individualNote) {
+        body['individual_note'] = true
+    }
 
     return internal_gitlabRequest(
         uri: "api/v4/projects/${params.projectId}/merge_requests/${params.mergeRequestId}/discussions",

--- a/vars/gitlab.groovy
+++ b/vars/gitlab.groovy
@@ -40,7 +40,10 @@ Map mergeRequestAuthor(Map params = [:]) {
  *                        project-specific ID, not the globally-unique ID. Required
  * :param gitlabCredentialsId: The credentials ID storing the GitLab access token to use.
  *                             Default is 'amber-gitlab-automaton-token'
- * :param individualNote: if true, make this an individual note instead of a thread
+ * :param individualNote: if true, make ethis an individual note instead of a thread
+ * :param files: A list of file names to upload. The message must have the tokens FILE1,
+                 FILE2, FILE3, ..., FILEN for i = 1 to the size of the list of files. These
+                 tokens will be replaced with the markdown links to the uploaded attachments.
  * :returns: the REST API response
  */
 Map mergeRequestComment(Map params = [:]) {
@@ -48,15 +51,39 @@ Map mergeRequestComment(Map params = [:]) {
     assert params.projectId : 'projectId is required'
     assert params.mergeRequestId : 'mergeRequestId is required'
 
-    Map body = ['body': params.message]
+    String message = params.message
+    String credentialsId = params.gitlabCredentialsId ?: defaultCredentialsId
+    String[] files = params.files ?: []
+
     if (params.individualNote) {
         body['individual_note'] = true
     }
 
+    if (files.size() > 1) {
+        for (int i = 1; i <= files.size(); i++) {
+            String token = "FILE${i}"
+            assert message.contains(token) : "${i}+ files were uploaded, but ${token} placeholder was not in message"
+            // Check that all files exist before we try uploading any
+            assert fileExists(files[i]) : "${files[i]} does not exist; cannot upload"
+        }
+        // If we got here, then we have all the necessary tokens and files all exist. Go ahead and upload each one
+        for (int i = 1; i <= files.size(); i++) {
+            Map response = internal_gitlabUploadAttachment(
+                projectId: params.projectId,
+                fileName: files[i],
+                credentialsId: credentialsId,
+            )
+            echo "INFO: Uploaded new attachment ${files[i]}"
+            message = message.replaceAll("FILE${i}", response.markdown)
+        }
+    }
+
+    Map body = ['body': message]
+
     return internal_gitlabRequest(
         uri: "api/v4/projects/${params.projectId}/merge_requests/${params.mergeRequestId}/discussions",
-        requestBody: JsonOutput.toJson(['body': params.message]),
-        credentialsId: params.gitlabCredentialsId ?: defaultCredentialsId,
+        requestBody: JsonOutput.toJson(body),
+        credentialsId: credentialsId,
         httpMode: 'POST',
     )
 }

--- a/vars/gitlab.txt
+++ b/vars/gitlab.txt
@@ -1,12 +1,24 @@
-<strong>String[] gitlab.mergeRequestAuthor()</strong>
+<strong>Map gitlab.mergeRequestAuthor()</strong>
 
 <p> Get the user details of the person that submitted the merge request </p>
 <ul>
     <li> projectId: The project identifier for the owner of the merge request. Required </li>
     <li> mergeRequestId: The MergeRequestIid (internal ID) specific to the project
          (not globally unique).</li>
-    <li> fetchRemote: name of the remote to fetch. If not set, nothing is fetched.
     <li> gitlabCredentialsId: the secret text with the user token for gitlab authentication</li>
 </ul>
 
 The returned results are a Map with keys id, name, username, state, avatar_url, and web_url
+
+<strong>Map gitlab.mergeRequestComment()</strong>
+
+<p> Make a comment on the specified merge request </p>
+<ul>
+    <li> projectId: The project identifier for the owner of the merge request. Required </li>
+    <li> mergeRequestId: The MergeRequestIid (internal ID) specific to the project
+         (not globally unique).</li>
+    <li> message: The message to post to the merge request </li>
+    <li> gitlabCredentialsId: the secret text with the user token for gitlab authentication</li>
+</ul>
+
+The returned results are a Map with response from the GitLab API with the details of the posted comment

--- a/vars/gitlab.txt
+++ b/vars/gitlab.txt
@@ -1,0 +1,12 @@
+<strong>String[] gitlab.mergeRequestAuthor()</strong>
+
+<p> Get the user details of the person that submitted the merge request </p>
+<ul>
+    <li> projectId: The project identifier for the owner of the merge request. Required </li>
+    <li> mergeRequestId: The MergeRequestIid (internal ID) specific to the project
+         (not globally unique).</li>
+    <li> fetchRemote: name of the remote to fetch. If not set, nothing is fetched.
+    <li> gitlabCredentialsId: the secret text with the user token for gitlab authentication</li>
+</ul>
+
+The returned results are a Map with keys id, name, username, state, avatar_url, and web_url

--- a/vars/gitlab.txt
+++ b/vars/gitlab.txt
@@ -18,6 +18,8 @@ The returned results are a Map with keys id, name, username, state, avatar_url, 
     <li> mergeRequestId: The MergeRequestIid (internal ID) specific to the project
          (not globally unique).</li>
     <li> message: The message to post to the merge request </li>
+    <li> files: the list of files to include as attachments. If provided, the message must have
+         tokens FILE1, FILE2, ..., FILEN where N is the total number of files in this list. </li>
     <li> gitlabCredentialsId: the secret text with the user token for gitlab authentication</li>
 </ul>
 


### PR DESCRIPTION
This allows a Jenkins pipeline to start posting comments and files to GitLab merge requests.  Full set of unit tests added for these functions and they've been verified to work on a PR in the Amber GitLab repository.