### PR TITLE
Improve change detection for branch builds

### DIFF
--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -25,12 +25,13 @@ boolean fileChangedIn(Map params = [:]) {
     }
 
     def changedFiles = []
+    Map result
     if (env.CHANGE_ID) {
         pullRequest.files.each { changedFiles << it.filename }
     } else {
         echo "INFO: Not a pull request; looking for changes since the last successful build"
         try {
-            Map result = filesChangedSinceLastSuccessfulBuild(params.githubApiUrl ?: "https://api.github.com", params.credentialsId ?: "")
+            result = filesChangedSinceLastSuccessfulBuild(params.githubApiUrl ?: "https://api.github.com", params.credentialsId ?: "")
         } catch(Exception ex) {
             echo "ERROR: Failed fetching change list [${ex}]. Assume something changed"
             return true

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -107,7 +107,9 @@ Map filesChangedSinceLastSuccessfulBuild(String githubApiUrl, String credentials
         response = readJSON(text: resp.getContent())
     }
 
-    changedFiles = response.files ?: []
+    (response.files ?: []).each { fileInfo ->
+        changedFiles.add(fileInfo.filename)
+    }
 
     return [changedFiles: changedFiles, foundSuccessfulBuild: true]
 }

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -81,7 +81,7 @@ Map filesChangedSinceLastSuccessfulBuild(String githubApiUrl, String credentials
     String apiUrl = "${githubApiUrl}/repos/${repoDetails.organization}/${repoDetails.repository}/compare/${lastCommit}...${currentCommit}"
 
     Map response
-    if (credentialsId == "") {
+    if (credentialsId == "" || credentialsId == null) {
         echo "INFO: Getting file changes via anonymous access"
         def resp = httpRequest(
             url: apiUrl.toString(),

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -132,7 +132,7 @@ void interrogateBuild() {
         echo "WARNING: Could not find all the information needed to identify changes."
     } else {
         echo "INFO: Should look for ${url}/${lastCommit}...${currentCommit}"
-        String noGit = url.replaceAll("\.git$", "")
+        String noGit = url.replaceAll("\\.git$", "")
         echo "Without .git: ${noGit}"
     }
     /*

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -113,7 +113,7 @@ String getRevisionFromBuild(RunWrapper build, String remoteUrl) {
                 echo "INFO: Matched SCM URL for build action"
                 gitHash = action.lastBuiltRevision.getSha1String()
                 return gitHash
-            }
+           }
         }
     }
 
@@ -127,7 +127,7 @@ String getRevisionFromBuild(RunWrapper build, String remoteUrl) {
 void interrogateBuild() {
     String url = getRemoteUrl()
     String currentCommit = getRevisionFromBuild(currentBuild, url)
-    String lastCommit = getRevisionFromBuild(currentBuild.lastSuccessfulBuild, url)
+    String lastCommit = getRevisionFromBuild(currentBuild.previousSuccessfulBuild, url)
     if (url == null || currentCommit == null || lastCommit == null) {
         echo "WARNING: Could not find all the information needed to identify changes."
     } else {

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -83,7 +83,8 @@ void interrogateBuild() {
             if (it.hasProperty("lastBuiltRevision")) {
                 echo "Last built revision = ${it.lastBuiltRevision} [${it.lastBuiltRevision.class.name}]"
                 echo "Last built revision sha1 = ${it.lastBuiltRevision.getSha1()} [${it.lastBuiltRevision.getSha1().class.name}]"
-                echo "Last built revision sha1 string = ${it.lastBuiltRevision.getSha1().toString()}"
+                def obj_id = it.lastBuiltRevision.getSha1()
+                echo "Last built revision sha1 string = ${obj.toString(obj.toObjectId())}"
             }
         }
         build = build.previousBuild

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -75,7 +75,7 @@ void interrogateBuild() {
         echo "Interrogating build actions:"
         build.rawBuild.getActions().each {
             if (it.hasProperty("lastBuiltRevision")) {
-                echo "Last built revision = ${it.SHA1}"
+                echo "Last built revision = ${it.lastBuiltRevision.SHA1}"
             }
         }
         build = build.previousBuild

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -31,8 +31,8 @@ boolean fileChangedIn(Map params = [:]) {
         echo "INFO: Not a pull request; looking for changes since the last successful build"
         try {
             Map result = filesChangedSinceLastSuccessfulBuild(params.githubApiUrl ?: "https://api.github.com", params.credentialsId ?: "")
-        } catch {
-            echo "ERROR: Failed fetching change list. Assume something changed"
+        } catch(Exception ex) {
+            echo "ERROR: Failed fetching change list [${ex}]. Assume something changed"
             return true
         }
         if (!result.foundSuccessfulBuild) {

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -132,7 +132,7 @@ void interrogateBuild() {
         echo "WARNING: Could not find all the information needed to identify changes."
     } else {
         echo "INFO: Should look for ${url}/${lastCommit}...${currentCommit}"
-        String noGit = url.replaceAll(".git", "")
+        String noGit = url.replaceAll("\.git$", "")
         echo "Without .git: ${noGit}"
     }
     /*

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -75,6 +75,7 @@ void interrogateBuild() {
     int i = 0
     echo "scm = ${scm}"
     echo "repositories = ${scm.getRepositories()}"
+    echo "URIs = ${scm.getRepositories()[0].getURIs()}"
     while (i < 2) {
         echo "Build ${build.id} had result ${build.result}"
         echo "Build variables = ${build.absoluteUrl}"

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -44,8 +44,12 @@ boolean fileChangedIn(Map params = [:]) {
 // Internal method for finding list of files that have changed since the last build
 Map filesChangedSinceLastSuccessfulBuild() {
     def changedFiles = []
-    boolean buildSucceeded = false
     def build = currentBuild
+    def lastSuccessfulBuild = currentBuild.previousSuccessfulBuild
+    if (lastSuccessfulBuild == null) {
+        echo "INFO: No previous successful build found"
+        return [changedFiles: changedFiles, foundSuccessfulBuild: false]
+    }
     echo "INFO: Looking for changes in build ${build}"
     while (build && !buildSucceeded) {
         echo "INFO: Build has ${build.changeSets.size()} change sets"
@@ -75,7 +79,7 @@ void interrogateBuild() {
         echo "Interrogating build actions:"
         build.rawBuild.getActions().each {
             if (it.hasProperty("lastBuiltRevision")) {
-                echo "Last built revision = ${it.lastBuiltRevision.SHA1}"
+                echo "Last built revision = ${it.lastBuiltRevision}"
             }
         }
         build = build.previousBuild

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -132,7 +132,7 @@ void interrogateBuild() {
         echo "WARNING: Could not find all the information needed to identify changes."
     } else {
         echo "INFO: Should look for ${url}/${lastCommit}...${currentCommit}"
-        String noGit = url.replaceAll("\\.git$", "")
+        String noGit = url.replaceAll("\\.git\$", "")
         echo "Without .git: ${noGit}"
     }
     /*

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -82,7 +82,7 @@ void interrogateBuild() {
             echo "BuildAction class name is ${it.class.name}"
             if (it.hasProperty("lastBuiltRevision")) {
                 echo "Last built revision = ${it.lastBuiltRevision} [${it.lastBuiltRevision.class.name}]"
-                echo "Last built revision sha1 = ${it.lastBuiltRevision.getSha1()}"
+                echo "Last built revision sha1 = ${it.lastBuiltRevision.getSha1()} [${it.lastBuiltRevision.getSha1().class.name}]"
             }
         }
         build = build.previousBuild

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -82,6 +82,7 @@ void interrogateBuild() {
             echo "BuildAction class name is ${it.class.name}"
             if (it.hasProperty("lastBuiltRevision")) {
                 echo "Last built revision = ${it.lastBuiltRevision} [${it.lastBuiltRevision.class.name}]"
+                echo "Last built revision sha1 = ${it.lastBuiltRevision.getSha1()}"
             }
         }
         build = build.previousBuild

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -76,6 +76,8 @@ void interrogateBuild() {
     echo "scm = ${scm}"
     echo "repositories = ${scm.getRepositories()}"
     echo "URIs = ${scm.getRepositories()[0].getURIs()}"
+    String url = ${scm.getRepositories()[0].getURIs()[0].toString()}
+    echo "First URL = ${url}"
     while (i < 2) {
         echo "Build ${build.id} had result ${build.result}"
         echo "Build variables = ${build.absoluteUrl}"

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -72,7 +72,8 @@ Map filesChangedSinceLastSuccessfulBuild() {
 
 void interrogateBuild() {
     def build = currentBuild
-    while (build != null) {
+    int i = 0
+    while (i < 2) {
         echo "Build ${build.id} had result ${build.result}"
         echo "Build variables = ${build.absoluteUrl}"
         echo "Build actions = ${build.rawBuild.getActions()}"
@@ -84,5 +85,6 @@ void interrogateBuild() {
             }
         }
         build = build.previousBuild
+        i++
     }
 }

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -132,6 +132,8 @@ void interrogateBuild() {
         echo "WARNING: Could not find all the information needed to identify changes."
     } else {
         echo "INFO: Should look for ${url}/${lastCommit}...${currentCommit}"
+        String noGit = url.replaceAll(".git", "")
+        echo "Without .git: ${noGit}"
     }
     /*
     int i = 0

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -167,7 +167,12 @@ String getRevisionFromBuild(RunWrapper build, String remoteUrl) {
     return gitHash
 }
 
-void interrogateBuild() {
+Map interrogateBuild(Map params = [:]) {
+    Map results = filesChangedSinceLastSuccessfulBuild("https://api.github.com", params.credentialsId)
+    echo "filesChangedSinceLastSuccessfulBuild: ${results}"
+    return results
+
+
     String url = getRemoteUrl()
     String currentCommit = getRevisionFromBuild(currentBuild, url)
     String lastCommit = getRevisionFromBuild(currentBuild.previousSuccessfulBuild, url)

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -72,6 +72,12 @@ void interrogateBuild() {
         echo "Build ${build.id} had result ${build.result}"
         echo "Build variables = ${build.absoluteUrl}"
         echo "Build actions = ${build.rawBuild.getActions()}"
+        echo "Interrogating build actions:"
+        build.rawBuild.getActions().each {
+            if (it.hasProperty("lastBuiltRevision")) {
+                echo "Last built revision = ${it}"
+            }
+        }
         build = build.previousBuild
     }
 }

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -6,6 +6,7 @@
  */
 import org.eclipse.jgit.transport.RemoteConfig
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
+import hudson.plugins.git.util.BuildData
 
 boolean fileChangedIn(Map params = [:]) {
     String path = params.path ?: ''
@@ -107,8 +108,8 @@ String getRevisionFromBuild(RunWrapper build, String remoteUrl) {
     String gitHash = null
 
     build.rawBuild.getActions().each { action ->
-        if (action instanceof hudson.plugins.git.util.BuildData) {
-            if (action.contains(remoteUrl)) {
+        if (action instanceof BuildData) {
+            if (action.getRemoteUrls().contains(remoteUrl)) {
                 echo "INFO: Matched SCM URL for build action"
                 gitHash = action.lastBuiltRevision.getSha1String()
                 return gitHash

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -75,7 +75,7 @@ void interrogateBuild() {
         echo "Interrogating build actions:"
         build.rawBuild.getActions().each {
             if (it.hasProperty("lastBuiltRevision")) {
-                echo "Last built revision = ${it}"
+                echo "Last built revision = ${it.SHA1}"
             }
         }
         build = build.previousBuild

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -135,7 +135,7 @@ void interrogateBuild() {
         String noGit = url.replaceAll("\\.git\$", "")
         echo "Without .git: ${noGit}"
         List<String> urlParts = noGit.split("/")
-        echo "Organization = ${urlParts[urlparts.size()-2]} repo = ${urlParts[urlParts.size()-1]}"
+        echo "Organization = ${urlParts[urlParts.size()-2]} repo = ${urlParts[urlParts.size()-1]}"
     }
     /*
     int i = 0

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -81,7 +81,7 @@ void interrogateBuild() {
         build.rawBuild.getActions().each {
             echo "BuildAction class name is ${it.class.name}"
             if (it.hasProperty("lastBuiltRevision")) {
-                echo "Last built revision = ${it.lastBuiltRevision}"
+                echo "Last built revision = ${it.lastBuiltRevision} [${it.lastBuiltRevision.class.name}]"
             }
         }
         build = build.previousBuild

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -83,6 +83,7 @@ void interrogateBuild() {
             if (it.hasProperty("lastBuiltRevision")) {
                 echo "Last built revision = ${it.lastBuiltRevision} [${it.lastBuiltRevision.class.name}]"
                 echo "Last built revision sha1 = ${it.lastBuiltRevision.getSha1()} [${it.lastBuiltRevision.getSha1().class.name}]"
+                echo "Last built revision sha1 string = ${it.lastBuiltRevision.getSha1().toString()}"
             }
         }
         build = build.previousBuild

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -134,6 +134,8 @@ void interrogateBuild() {
         echo "INFO: Should look for ${url}/${lastCommit}...${currentCommit}"
         String noGit = url.replaceAll("\\.git\$", "")
         echo "Without .git: ${noGit}"
+        List<String> urlParts = noGit.split("/")
+        echo "Organization = ${urlParts[urlparts.size()-2]} repo = ${urlParts[urlParts.size()-1]}"
     }
     /*
     int i = 0

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -3,17 +3,13 @@
  * the files changed are available in the build information. The credentials and GitHub API will
  * only be used for branch builds where CHANGE_ID is not set.
  *
- * This check does *not* require an allocated executor.
+ * This check falls back on the git command-line for branch builds, so it requires an allocated
+ * executor and must be executed from inside a git repository that has its full history checked
+ * out.
  *
  * :param path: Name of the file or path prefix where changes should be looked for
  * :param paths: A list of file or path prefix names where changes should be looked for
- * :param credentialsId: A set of username/password credentials to access the GitHub API (needed only for private repos)
- * :param githubApiUrl: The API URL for the GitHub instance. Default is https://api.github.com
  */
-import org.eclipse.jgit.transport.RemoteConfig
-import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
-import hudson.plugins.git.util.BuildData
-
 boolean fileChangedIn(Map params = [:]) {
     String path = params.path ?: ''
     def paths = params.paths ?: []
@@ -30,18 +26,9 @@ boolean fileChangedIn(Map params = [:]) {
         pullRequest.files.each { changedFiles << it.filename }
     } else {
         echo "INFO: Not a pull request; looking for changes since the last successful build"
-        try {
-            result = filesChangedSinceLastSuccessfulBuild(params.githubApiUrl ?: "https://api.github.com", params.credentialsId ?: "")
-        } catch(Exception ex) {
-            echo "ERROR: Failed fetching change list [${ex}]. Assume something changed"
-            return true
-        }
+        result = filesChangedSinceLastSuccessfulBuild()
         if (!result.foundSuccessfulBuild) {
             echo "WARNING: Did not find a prior successful build. Forcibly saying yes"
-            return true
-        }
-        if (result.changedFiles.size() == 0) {
-            echo "WARNING: No changed files found. Forcibly saying yes"
             return true
         }
         changedFiles = result.changedFiles
@@ -59,8 +46,7 @@ boolean fileChangedIn(Map params = [:]) {
 }
 
 // Internal method for finding list of files that have changed since the last build
-Map filesChangedSinceLastSuccessfulBuild(String githubApiUrl, String credentialsId) {
-    def changedFiles = []
+Map filesChangedSinceLastSuccessfulBuild() {
     String remoteUrl = getRemoteUrl()
     String currentCommit = getRevisionFromBuild(currentBuild, remoteUrl)
     String lastCommit = getRevisionFromBuild(currentBuild.previousSuccessfulBuild, remoteUrl)
@@ -69,54 +55,12 @@ Map filesChangedSinceLastSuccessfulBuild(String githubApiUrl, String credentials
         echo "INFO: Not enough information to determine any file changes."
         return [changedFiles: changedFiles, foundSuccessfulBuild: false]
     }
-
-    Map repoDetails = getOrganizationRepoFromRemote(remoteUrl)
-
-    if (!repoDetails.organization || !repoDetails.repository) {
-        echo "ERROR: Could not find organization or repository from ${remoteUrl}"
-        return [changedFiles: changedFiles, foundSuccessfulBuild: false]
-    }
-
-    String org = repoDetails.organization
-
-    String apiUrl = "${githubApiUrl}/repos/${repoDetails.organization}/${repoDetails.repository}/compare/${lastCommit}...${currentCommit}"
-
-    Map response
-    if (credentialsId == "" || credentialsId == null) {
-        echo "INFO: Getting file changes via anonymous access"
-        def resp = httpRequest(
-            url: apiUrl.toString(),
-            acceptType: 'APPLICATION_JSON',
-            contentType: 'APPLICATION_JSON',
-            httpMode: 'GET',
-            validResponseCodes: '100:399',
-        )
-        response = readJSON(text: resp.getContent())
-    } else {
-        withCredentials([string(credentialsId: credentialsId, variable: 'GITHUB_TOKEN')]) {
-            def resp = httpRequest(
-                url: apiUrl.toString(),
-                acceptType: 'APPLICATION_JSON',
-                contentType: 'APPLICATION_JSON',
-                httpMode: 'GET',
-                validResponseCodes: '100:399',
-                customHeaders = [
-                    [name: 'Authorization', value: "token ${GITHUB_TOKEN}", maskValue: true]
-                ]
-            )
-        }
-        response = readJSON(text: resp.getContent())
-    }
-
-    (response.files ?: []).each { fileInfo ->
-        changedFiles.add(fileInfo.filename)
-    }
-
+    List<String> changedFiles = git.diffFiles(targetRef: lastCommit, sourceRef: currentCommit)
     return [changedFiles: changedFiles, foundSuccessfulBuild: true]
 }
 
 String getRemoteUrl() {
-    List<RemoteConfig> repositories = scm.getRepositories()
+    List repositories = scm.getRepositories()
     if (repositories.size() < 1) {
         echo "ERROR: No remote repository detected. Is the Jenkinsfile fetched from source?"
         return null
@@ -140,12 +84,7 @@ String getRemoteUrl() {
     return urls[0];
 }
 
-Map getOrganizationRepoFromRemote(String url) {
-    List<String> urlParts = url.replaceAll("\\.git\$", "").split("/")
-    return [organization: urlParts[urlParts.size() - 2], repository: urlParts[urlParts.size() - 1]]
-}
-
-String getRevisionFromBuild(RunWrapper build, String remoteUrl) {
+String getRevisionFromBuild(def build, String remoteUrl) {
     if (build == null) {
         echo "INFO: No build given, so unable to find revision id"
         return null
@@ -154,7 +93,7 @@ String getRevisionFromBuild(RunWrapper build, String remoteUrl) {
     String gitHash = null
 
     build.rawBuild.getActions().each { action ->
-        if (action instanceof BuildData) {
+        if (action.hasProperty("getRemoteUrls")) {
             if (action.getRemoteUrls().contains(remoteUrl)) {
                 echo "INFO: Matched SCM URL for build action"
                 gitHash = action.lastBuiltRevision.getSha1String()
@@ -168,49 +107,4 @@ String getRevisionFromBuild(RunWrapper build, String remoteUrl) {
     }
 
     return gitHash
-}
-
-Map interrogateBuild(Map params = [:]) {
-    Map results = filesChangedSinceLastSuccessfulBuild("https://api.github.com", params.credentialsId)
-    echo "filesChangedSinceLastSuccessfulBuild: ${results}"
-    return results
-
-
-    String url = getRemoteUrl()
-    String currentCommit = getRevisionFromBuild(currentBuild, url)
-    String lastCommit = getRevisionFromBuild(currentBuild.previousSuccessfulBuild, url)
-    if (url == null || currentCommit == null || lastCommit == null) {
-        echo "WARNING: Could not find all the information needed to identify changes."
-    } else {
-        echo "INFO: Should look for ${url}/${lastCommit}...${currentCommit}"
-        String noGit = url.replaceAll("\\.git\$", "")
-        echo "Without .git: ${noGit}"
-        List<String> urlParts = noGit.split("/")
-        echo "Organization = ${urlParts[urlParts.size()-2]} repo = ${urlParts[urlParts.size()-1]}"
-    }
-    /*
-    int i = 0
-    echo "scm = ${scm}"
-    echo "repositories = ${scm.getRepositories()}"
-    echo "URIs = ${scm.getRepositories()[0].getURIs()}"
-    String url = ${scm.getRepositories()[0].getURIs()[0].toString()}
-    echo "First URL = ${url}"
-    while (i < 2) {
-        echo "Build ${build.id} had result ${build.result}"
-        echo "Build variables = ${build.absoluteUrl}"
-        echo "Build actions = ${build.rawBuild.getActions()}"
-        echo "Interrogating build actions:"
-        build.rawBuild.getActions().each {
-            echo "BuildAction class name is ${it.class.name}"
-            if (it instanceof hudson.plugins.git.util.BuildData) {
-                echo "Last built revision = ${it.lastBuiltRevision} [${it.lastBuiltRevision.class.name}]"
-                echo "Last built revision sha1 = ${it.lastBuiltRevision.getSha1String()}"
-                echo "Remote URLs: ${it.getRemoteUrls()}"
-                echo "SCM Name: ${it.getScmName()}"
-            }
-        }
-        build = build.previousSuccessfulBuild
-        i++
-    }
-    */
 }

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -74,6 +74,7 @@ void interrogateBuild() {
     def build = currentBuild
     int i = 0
     echo "scm = ${scm}"
+    echo "repositories = ${scm.getRepositories()}"
     while (i < 2) {
         echo "Build ${build.id} had result ${build.result}"
         echo "Build variables = ${build.absoluteUrl}"

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -82,9 +82,7 @@ void interrogateBuild() {
             echo "BuildAction class name is ${it.class.name}"
             if (it.hasProperty("lastBuiltRevision")) {
                 echo "Last built revision = ${it.lastBuiltRevision} [${it.lastBuiltRevision.class.name}]"
-                echo "Last built revision sha1 = ${it.lastBuiltRevision.getSha1()} [${it.lastBuiltRevision.getSha1().class.name}]"
-                def obj_id = it.lastBuiltRevision.getSha1()
-                echo "Last built revision sha1 string = ${obj.toString(obj.toObjectId())}"
+                echo "Last built revision sha1 = ${it.lastBuiltRevision.getSha1String()}"
             }
         }
         build = build.previousBuild

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -80,9 +80,11 @@ void interrogateBuild() {
         echo "Interrogating build actions:"
         build.rawBuild.getActions().each {
             echo "BuildAction class name is ${it.class.name}"
-            if (it.hasProperty("lastBuiltRevision")) {
+            if (it instanceof hudson.plugins.git.util.BuildData) {
                 echo "Last built revision = ${it.lastBuiltRevision} [${it.lastBuiltRevision.class.name}]"
                 echo "Last built revision sha1 = ${it.lastBuiltRevision.getSha1String()}"
+                echo "Remote URLs: ${it.getRemoteUrls()}"
+                echo "SCM Name: ${it.getScmName()}"
             }
         }
         build = build.previousSuccessfulBuild

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -85,7 +85,7 @@ void interrogateBuild() {
                 echo "Last built revision sha1 = ${it.lastBuiltRevision.getSha1String()}"
             }
         }
-        build = build.previousBuild
+        build = build.previousSuccessfulBuild
         i++
     }
 }

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -78,6 +78,7 @@ void interrogateBuild() {
         echo "Build actions = ${build.rawBuild.getActions()}"
         echo "Interrogating build actions:"
         build.rawBuild.getActions().each {
+            echo "BuildAction class name is ${it.class.name}"
             if (it.hasProperty("lastBuiltRevision")) {
                 echo "Last built revision = ${it.lastBuiltRevision}"
             }

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -65,3 +65,13 @@ Map filesChangedSinceLastSuccessfulBuild() {
 
     return [changedFiles: changedFiles, foundSuccessfulBuild: buildSucceeded]
 }
+
+void interrogateBuild() {
+    def build = currentBuild
+    while (build != null) {
+        echo "Build ${build.id} had result ${build.result}"
+        echo "Build variables = ${build.absoluteUrl}"
+        echo "Build actions = ${build.actions}"
+        build = build.previousBuild
+    }
+}

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -71,7 +71,7 @@ void interrogateBuild() {
     while (build != null) {
         echo "Build ${build.id} had result ${build.result}"
         echo "Build variables = ${build.absoluteUrl}"
-        echo "Build actions = ${build.actions}"
+        echo "Build actions = ${build.rawBuild.getActions()}"
         build = build.previousBuild
     }
 }

--- a/vars/github.groovy
+++ b/vars/github.groovy
@@ -73,6 +73,7 @@ Map filesChangedSinceLastSuccessfulBuild() {
 void interrogateBuild() {
     def build = currentBuild
     int i = 0
+    echo "scm = ${scm}"
     while (i < 2) {
         echo "Build ${build.id} had result ${build.result}"
         echo "Build variables = ${build.absoluteUrl}"


### PR DESCRIPTION
This was a lot of experimentation, but it turns out that the GitHub API simply isn't reliable enough to avoid using git directly.  Unfortunately this means that the `fileChangedIn` method will require a running executor to work :(.