### PR TITLE
Stop false-succeeding when asking for an apply log

### DIFF
--- a/test/groovy/TerraformTest.groovy
+++ b/test/groovy/TerraformTest.groovy
@@ -16,8 +16,9 @@ class TerraformTest extends BasePipelineTest {
     @Test
     void 'verify plan defaults'() {
         def script = loadScript('vars/terraform.groovy')
-        script.metaClass.terraformCommand = {String command, String args, boolean errorOnFailure ->
+        script.metaClass.terraformCommand = {String command, String args, boolean errorOnFailure, String outputFile = '' ->
             assert command == 'plan'
+            assert outputFile == ''
             assert args.trim() == '-out terraform.plan'
             assert errorOnFailure
             return true
@@ -28,8 +29,9 @@ class TerraformTest extends BasePipelineTest {
     @Test
     void 'verify custom args and plan output support'() {
         def script = loadScript('vars/terraform.groovy')
-        script.metaClass.terraformCommand = {String command, String args, boolean errorOnFailure ->
+        script.metaClass.terraformCommand = {String command, String args, boolean errorOnFailure, String outputFile = '' ->
             assert command == 'plan'
+            assert outputFile == ''
             assert args.trim() == '-some-arg foo -other-arg bar -out baloney.plan'
             assert errorOnFailure
             return true
@@ -40,8 +42,9 @@ class TerraformTest extends BasePipelineTest {
     @Test
     void 'verify custom args with apply'() {
         def script = loadScript('vars/terraform.groovy')
-        script.metaClass.terraformCommand = {String command, String args, boolean errorOnFailure ->
+        script.metaClass.terraformCommand = {String command, String args, boolean errorOnFailure, String outputFile = '' ->
             assert command == 'apply'
+            assert outputFile == ''
             assert args.trim() == '-some-arg foo -other-arg bar -auto-approve'
             assert errorOnFailure
             return true
@@ -52,9 +55,10 @@ class TerraformTest extends BasePipelineTest {
     @Test
     void 'verify apply with log output file'() {
         def script = loadScript('vars/terraform.groovy')
-        script.metaClass.terraformCommand = {String command, String args, boolean errorOnFailure ->
+        script.metaClass.terraformCommand = {String command, String args, boolean errorOnFailure, String outputFile = '' ->
             assert command == 'apply'
-            assert args.trim() == '-auto-approve | tee terraform.log'
+            assert outputFile == 'terraform.log'
+            assert args.trim() == '-auto-approve'
             assert errorOnFailure
             return true
         }

--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -127,9 +127,9 @@ boolean validate(Map params = [:]) {
 /**
  * Internal function for running terraform command. Backwards compatibility is not guaranteed
  */
-boolean terraformCommand(String command, String args, boolean errorOnFailure, String outputFile = "") {
+boolean terraformCommand(String command, String args, boolean errorOnFailure, String outputFile = '') {
     boolean succeeded
-    if (outputFile == "") {
+    if (outputFile == '') {
         succeeded = sh(
             label: "Terraform ${command}",
             script: "${env.WORKSPACE}/terraform ${command} ${args}",

--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -92,10 +92,8 @@ boolean init(Map params = [:]) {
 boolean apply(Map params = [:]) {
     boolean errorOnFailure = params.getOrDefault('errorOnFailure', true)
     String args = params.args ?: ''
-    if (params.fileName) {
-        return terraformCommand('apply', "${args} -auto-approve | tee ${params.fileName}", errorOnFailure)
-    }
-    return terraformCommand('apply', "${args} -auto-approve", errorOnFailure)
+    String outputFile = params.fileName ?: ''
+    return terraformCommand('apply', "${args} -auto-approve", errorOnFailure, outputFile)
 }
 
 /**
@@ -129,10 +127,28 @@ boolean validate(Map params = [:]) {
 /**
  * Internal function for running terraform command. Backwards compatibility is not guaranteed
  */
-boolean terraformCommand(String command, String args, boolean errorOnFailure) {
-    boolean succeeded = sh(label: "Terraform ${command}",
-                           script: "${env.WORKSPACE}/terraform ${command} ${args}",
-                           returnStatus: true) == 0
+boolean terraformCommand(String command, String args, boolean errorOnFailure, String outputFile = "") {
+    boolean succeeded
+    if (outputFile == "") {
+        succeeded = sh(
+            label: "Terraform ${command}",
+            script: "${env.WORKSPACE}/terraform ${command} ${args}",
+            returnStatus: true
+        ) == 0
+    } else {
+        succeeded = sh(label: "Terraform ${command}", script: """#!/bin/sh
+                ${env.WORKSPACE}/terraform ${command} ${args} > ${outputFile}
+                if [ \$? -ne 0 ]; then
+                    echo "ERROR in terraform ${command}"
+                    cat ${outputFile}
+                    exit 1
+                fi
+                cat ${outputFile}
+                exit 0
+            """,
+            returnStatus: true
+        ) == 0
+    }
 
     if (!succeeded && errorOnFailure) {
         error("Failed terraform ${command} - see the logs for additional details")


### PR DESCRIPTION
This is the clunky workaround for not having -o pipefail in alpine