### PR TITLE
Fix git merge cleanup after failed merges

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.21</version>
+            <version>1.26</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/vars/git.groovy
+++ b/vars/git.groovy
@@ -100,8 +100,8 @@ Map merge(Map params = [:]) {
                 label: 'reset git repo following failed merge',
                 script: """#!/bin/bash
                     set -e
-                    echo "Resetting the git repository to ${remote}/${params.targetBranch}"
-                    git reset --hard ${remote}/${params.targetBranch}
+                    echo "Resetting the git repository to ${remote}/${params.currentBranch}"
+                    git reset --hard ${remote}/${params.currentBranch}
                 """, returnStatus: true
             ) == 0
             if (failedToReset) {

--- a/vars/git.groovy
+++ b/vars/git.groovy
@@ -95,6 +95,19 @@ Map merge(Map params = [:]) {
             git config user.email "no-reply@ambermd.org"
             git merge --no-edit ${remote}/${params.targetBranch} > merge_output.txt
         """, returnStatus: true) != 0
+        if (hasFailed) {
+            boolean failedToReset = sh(
+                label: 'reset git repo following failed merge',
+                script: """#!/bin/bash
+                    set -e
+                    echo "Resetting the git repository to ${remote}/${params.targetBranch}"
+                    git reset --hard ${remote}/${params.targetBranch}
+                """, returnStatus: true
+            ) == 0
+            if (failedToReset) {
+                echo "WARNING: Failed resetting the branch with `git reset`. This may need to be fixed by hand."
+            }
+        }
     }
     String mergeText = readFile('merge_output.txt').trim()
 


### PR DESCRIPTION
For Jenkins jobs that don't start with a "new" git repo each CI run, a failed `git.merge()` call could leave the repo in a broken (partially merged) state with conflicts.  This will prevent every subsequent run from completing in the future.